### PR TITLE
fix: bugfix when last() with null value throws exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ An interrupt is any source of input (typically from the user, but could be thing
 - `EventTargetInterruptSource`: Any object that implements `EventTarget`, such as an `HTMLElement` or `Window`. Takes in the object that is the source and a space delimited string containing the events that cause an interrupt.
 - `DocumentInterruptSource`: Looks for events (in a space delimited string) that bubble up to the `document.documentElement` (`html` node).
 - `WindowInterruptSource`: Looks for events (in a space delimited string) that bubble up to the `Window`.
+- `StorageInterruptSource`: Looks only for the `Storage` event of `Window` object. Obligatory for `LocalStorageExpiry`.
 
 **NOTE**: You must configure source(s) yourself when you initialize the application. By default, no interrupts are configured. You can use a configuration analogous to the `ng-idle` default by importing `DEFAULT_INTERRUPTSOURCES` and passing that reference to `Idle.setInterrupts(DEFAULT_INTERRUPTSOURCES);`.
 
@@ -50,7 +51,8 @@ Another feature ported from `ng-idle` is the ability to store an expiry value in
 By default, a `LocalStorageExpiry` type is provided, which will just keep track of the expiry in the localStorage. It will fulfill all purposes mentioned above. If you don't want to support multiple tabs or windows, you can use `SimpleExpiry`. In other words, `SimpleExpiry` does not coordinate last activity between tabs or windows. If you want to store the expiry value in another store, like cookies, you'll need to use or create an implementation that supports that. You can create your own by extending `IdleExpiry` or `SimpleExpiry` and configuring it as a provider for the `IdleExpiry` class.
 
 ### Multiple Idle Instance Support
-The dependency injector in Angular 2 supports a hierarchical injection strategy. This allows you to create an instance of `Idle` at whatever scope you need, and there can be more than one instance. This allows you two have two separate watches, for example, on two different elements on the page.
+The dependency injector in Angular 2 supports a hierarchical injection strategy. This allows you to create an instance of `Idle` at whatever scope you need, and there can be more than one instance. This allows you two have two separate watches, for example, on two different elements on the page.  
+If you use the default expiry (`LocalStorageExpiry`), you will need to define a name for each idle with `Idle.setIdleName('yourIdleName')`, otherwise the same key will be used in the localStorage and this feature will not work as expected. 
 
 ### Example Use Case
 For example, consider an email application. For increased security, the application may wish to determine when the user is inactive and log them out, giving them a chance to extend their session if they are still at the computer and just got distracted. Additionally, for even better security the server may issue the user's session a security token that expires after 5 minutes of inactivity. The user may take much more time than that to type out their email and send it. It would be frustrating to find you are logged out when you were actively using the software!

--- a/modules/core/src/idle.spec.ts
+++ b/modules/core/src/idle.spec.ts
@@ -19,9 +19,9 @@ describe('core/Idle', () => {
         { providers: [LocalStorageExpiry, LocalStorage, { provide: IdleExpiry, useExisting: LocalStorageExpiry }, Idle] });
     });
 
-    it('setExpiryKey() should set expiry key name', inject([Idle, LocalStorageExpiry], (idle: Idle, exp: LocalStorageExpiry) => {
-      idle.setExpiryKey('newKeyName');
-      expect((exp as LocalStorageExpiry).getExpiryKey()).toBe('newKeyName');
+    it('setIdleName() should set idle name', inject([Idle, LocalStorageExpiry], (idle: Idle, exp: LocalStorageExpiry) => {
+      idle.setIdleName('demo');
+      expect((exp as LocalStorageExpiry).getIdleName()).toBe('demo');
     }));
   });
 
@@ -63,9 +63,9 @@ describe('core/Idle', () => {
         expect(actual).toEqual(expected);
       });
 
-      it('setExpiryKey() when expiry is not instance of LocalStorageExpiry should throw error', () => {
+      it('setIdleName() when expiry is not instance of LocalStorageExpiry should throw error', () => {
         expect(() => {
-          instance.setExpiryKey('newKeyName');
+          instance.setIdleName('demo');
         })
           .toThrowError(
           'Cannot set expiry key name because no LocalStorageExpiry has been provided.');

--- a/modules/core/src/idle.ts
+++ b/modules/core/src/idle.ts
@@ -59,12 +59,13 @@ export class Idle implements OnDestroy {
   }
 
   /*
-   * Sets the expiry key name for localStorage.
-   * @param The name of the expiry key.
+   * Sets the idle name for localStorage.
+   * Important to set if multiple instances of Idle with LocalStorageExpiry
+   * @param The name of the idle.
    */
-  setExpiryKey(key: string): void {
+  setIdleName(key: string): void {
     if (this.expiry instanceof LocalStorageExpiry) {
-      this.expiry.setExpiryKey(key);
+      this.expiry.setIdleName(key);
     } else {
       throw new Error('Cannot set expiry key name because no LocalStorageExpiry has been provided.');
     }
@@ -247,7 +248,7 @@ export class Idle implements OnDestroy {
     this.safeClearInterval('idleHandle');
     this.safeClearInterval('timeoutHandle');
 
-    this.idling = false;
+    this.setIdling(false);
     this.running = false;
 
     this.expiry.last(null);
@@ -264,7 +265,7 @@ export class Idle implements OnDestroy {
     this.safeClearInterval('idleHandle');
     this.safeClearInterval('timeoutHandle');
 
-    this.idling = true;
+    this.setIdling(true);
     this.running = false;
     this.countdown = 0;
 
@@ -288,13 +289,18 @@ export class Idle implements OnDestroy {
     this.onInterrupt.emit(eventArgs);
 
     if (force === true || this.autoResume === AutoResume.idle ||
-        (this.autoResume === AutoResume.notIdle && !this.idling)) {
+        (this.autoResume === AutoResume.notIdle && !this.expiry.idling())) {
       this.watch(force);
     }
   }
 
+  private setIdling(value: boolean): void {
+    this.idling = value;
+    this.expiry.idling(value);
+  }
+
   private toggleState(): void {
-    this.idling = !this.idling;
+    this.setIdling(!this.idling);
 
     if (this.idling) {
       this.onIdleStart.emit(null);

--- a/modules/core/src/idleexpiry.spec.ts
+++ b/modules/core/src/idleexpiry.spec.ts
@@ -30,6 +30,22 @@ describe('core/IdleExpiry', () => {
     expect(actual).toEqual(expected);
   });
 
+  it('idling() returns the current value', () => {
+    expect(instance.idling()).toBeFalsy();
+  });
+
+  it('idling() sets the specified value', () => {
+    let expected = true;
+    expect(instance.idling(expected)).toEqual(expected);
+    expect(instance.idling()).toEqual(expected);
+  });
+
+  it('idling() with null param return null', () => {
+    let expected = null;
+    expect(instance.idling(expected)).toEqual(expected);
+    expect(instance.idling()).toEqual(expected);
+  });
+
   it('isExpired() returns true if last() is less than or equal to now', () => {
     let date = new Date();
     instance.last(date);
@@ -52,4 +68,5 @@ describe('core/IdleExpiry', () => {
     instance.last(null);
     expect(instance.isExpired()).toBe(false);
   });
+
 });

--- a/modules/core/src/idleexpiry.ts
+++ b/modules/core/src/idleexpiry.ts
@@ -3,9 +3,11 @@
  */
 export abstract class IdleExpiry {
   protected idValue: any;
+  protected idlingValue: boolean;
 
   constructor() {
     this.idValue = new Date();
+    this.idlingValue = false;
   }
 
   /*
@@ -31,6 +33,19 @@ export abstract class IdleExpiry {
    * @return The last expiry value.
    */
   abstract last(value?: Date): Date;
+
+  /*
+   * Gets or sets the idling value.
+   * @param value - The value to set.
+   * @return The idling value.
+   */
+  idling(value?: boolean): boolean {
+    if (value !== void 0) {
+      this.idlingValue = value;
+    }
+
+    return this.idlingValue;
+  }
 
   /*
    * Returns the current Date.

--- a/modules/core/src/localstorageexpiry.spec.ts
+++ b/modules/core/src/localstorageexpiry.spec.ts
@@ -27,22 +27,44 @@ describe('core/LocalStorageExpiry', () => {
     expect(service.last()).toEqual(expected);
   }));
 
-  it('setExpiryKey() sets the key name of expiry', inject([LocalStorageExpiry], (service: LocalStorageExpiry) => {
-    expect(service.getExpiryKey()).toBe('expiry');
-    service.setExpiryKey('name');
-    expect(service.getExpiryKey()).toBe('name');
+  it('idling() returns the current value', inject([LocalStorageExpiry], (service: LocalStorageExpiry) => {
+    expect(service.idling()).toBeFalsy();
   }));
 
-  it('setExpiryKey() doesn\'t set expiry key name if param is null', inject([LocalStorageExpiry], (service: LocalStorageExpiry) => {
-    expect(service.getExpiryKey()).toBe('expiry');
-    service.setExpiryKey(null);
-    expect(service.getExpiryKey()).toBe('expiry');
+  it('idling() sets the specified value', inject([LocalStorageExpiry], (service: LocalStorageExpiry) => {
+    let expected = true;
+    expect(service.idling(expected)).toEqual(expected);
+    expect(service.idling()).toEqual(expected);
   }));
 
-  it('setExpiryKey() doesn\'t set expiry key name if param is empty', inject([LocalStorageExpiry], (service: LocalStorageExpiry) => {
-    expect(service.getExpiryKey()).toBe('expiry');
-    service.setExpiryKey('');
-    expect(service.getExpiryKey()).toBe('expiry');
+  it('idling() with null param return false', inject([LocalStorageExpiry], (service: LocalStorageExpiry) => {
+    let expected = false;
+    expect(service.idling(null)).toEqual(expected);
+    expect(service.idling()).toEqual(expected);
+  }));
+
+  it('last() return false if param is null', inject([LocalStorageExpiry], (service: LocalStorageExpiry) => {
+    let expected = false;
+    expect(service.idling(null)).toEqual(expected);
+    expect(service.idling()).toEqual(expected);
+  }));
+
+  it('setIdleName() sets the key name of expiry', inject([LocalStorageExpiry], (service: LocalStorageExpiry) => {
+    expect(service.getIdleName()).toBe('main');
+    service.setIdleName('demo');
+    expect(service.getIdleName()).toBe('demo');
+  }));
+
+  it('setIdleName() doesn\'t set expiry key name if param is null', inject([LocalStorageExpiry], (service: LocalStorageExpiry) => {
+    expect(service.getIdleName()).toBe('main');
+    service.setIdleName(null);
+    expect(service.getIdleName()).toBe('main');
+  }));
+
+  it('setIdleName() doesn\'t set expiry key name if param is empty', inject([LocalStorageExpiry], (service: LocalStorageExpiry) => {
+    expect(service.getIdleName()).toBe('main');
+    service.setIdleName('');
+    expect(service.getIdleName()).toBe('main');
   }));
 
 });

--- a/modules/core/src/localstorageexpiry.spec.ts
+++ b/modules/core/src/localstorageexpiry.spec.ts
@@ -21,6 +21,12 @@ describe('core/LocalStorageExpiry', () => {
     expect(service.last()).toEqual(expected);
   }));
 
+  it('last() remove value and return null if param is null', inject([LocalStorageExpiry], (service: LocalStorageExpiry) => {
+    let expected = null;
+    expect(service.last(expected)).toEqual(expected);
+    expect(service.last()).toEqual(expected);
+  }));
+
   it('setExpiryKey() sets the key name of expiry', inject([LocalStorageExpiry], (service: LocalStorageExpiry) => {
     expect(service.getExpiryKey()).toBe('expiry');
     service.setExpiryKey('name');

--- a/modules/core/src/localstorageexpiry.ts
+++ b/modules/core/src/localstorageexpiry.ts
@@ -9,7 +9,7 @@ import { LocalStorage } from './localstorage';
 @Injectable()
 export class LocalStorageExpiry extends IdleExpiry {
 
-  private expiryKey: string = 'expiry';
+  private idleName: string = 'main';
 
   constructor(private localStorage: LocalStorage) {
     super();
@@ -28,26 +28,33 @@ export class LocalStorageExpiry extends IdleExpiry {
     return this.getExpiry();
   }
 
-  /*
-   * Gets the expiry key name.
-   * @return The name of the expiry key.
-   */
-  getExpiryKey(): string {
-    return this.expiryKey;
+  idling(value?: boolean): boolean {
+    if (value !== void 0) {
+      this.setIdling(value);
+    }
+    return this.getIdling();
   }
 
   /*
-   * Sets the expiry key name.
-   * @param The name of the expiry key.
+   * Gets the idle name.
+   * @return The name of the idle.
    */
-  setExpiryKey(key: string): void {
+  getIdleName(): string {
+    return this.idleName;
+  }
+
+  /*
+   * Sets the idle name.
+   * @param The name of the idle.
+   */
+  setIdleName(key: string): void {
     if (key) {
-      this.expiryKey = key;
+      this.idleName = key;
     }
   }
 
   private getExpiry(): Date {
-    let expiry: string = this.localStorage.getItem(this.expiryKey);
+    let expiry: string = this.localStorage.getItem(this.idleName + '.expiry');
     if (expiry) {
       return new Date(parseInt(expiry, 10));
     } else {
@@ -57,9 +64,26 @@ export class LocalStorageExpiry extends IdleExpiry {
 
   private setExpiry(value: Date) {
     if (value) {
-      this.localStorage.setItem(this.expiryKey, value.getTime().toString());
+      this.localStorage.setItem(this.idleName + '.expiry', value.getTime().toString());
     } else {
-      this.localStorage.removeItem(this.expiryKey);
+      this.localStorage.removeItem(this.idleName + '.expiry');
+    }
+  }
+
+  private getIdling(): boolean {
+    let idling: string = this.localStorage.getItem(this.idleName + '.idling');
+    if (idling) {
+      return idling === 'true';
+    } else {
+      return false;
+    }
+  }
+
+  private setIdling(value: boolean) {
+    if (value) {
+      this.localStorage.setItem(this.idleName + '.idling', value.toString());
+    } else {
+      this.localStorage.setItem(this.idleName + '.idling', 'false');
     }
   }
 

--- a/modules/core/src/localstorageexpiry.ts
+++ b/modules/core/src/localstorageexpiry.ts
@@ -56,7 +56,11 @@ export class LocalStorageExpiry extends IdleExpiry {
   }
 
   private setExpiry(value: Date) {
-    this.localStorage.setItem(this.expiryKey, value.getTime().toString());
+    if (value) {
+      this.localStorage.setItem(this.expiryKey, value.getTime().toString());
+    } else {
+      this.localStorage.removeItem(this.expiryKey);
+    }
   }
 
 }

--- a/modules/core/src/storageinterruptsource.ts
+++ b/modules/core/src/storageinterruptsource.ts
@@ -14,7 +14,7 @@ export class StorageInterruptSource extends WindowInterruptSource {
    * @return True if the event should be filtered (don't cause an interrupt); otherwise, false.
    */
   filterEvent(event: StorageEvent): boolean {
-    if (event.key.indexOf('ng2Idle.') >= 0) {
+    if (event.key.indexOf('ng2Idle.') >= 0 && event.key.indexOf('.expiry') >= 0) {
       return false;
     }
     return true;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/HackedByChinese/ng2-idle/blob/master/CONTRIBUTING.md#pr
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
LocalStorageExpiry -> last() with null value throws error because null.getTime() doesn't exists


**What is the new behavior?**
Add some validation on parameters to check if param is null. 
If null, remove key on localStorge, otherwise, set key


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[X] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
