### PR TITLE
fix: Initialize localStorage idling value to false in constructor

### DIFF
--- a/modules/core/src/idle.ts
+++ b/modules/core/src/idle.ts
@@ -36,7 +36,7 @@ export class Idle implements OnDestroy {
   private autoResume: AutoResume = AutoResume.idle;
   private interrupts: Array<Interrupt> = new Array;
   private running: boolean = false;
-  private idling: boolean = false;
+  private idling: boolean;
   private idleHandle: any;
   private timeoutHandle: any;
   private countdown: number;
@@ -56,6 +56,7 @@ export class Idle implements OnDestroy {
       this.keepaliveSvc = keepaliveSvc;
       this.keepaliveEnabled = true;
     }
+    this.setIdling(false);
   }
 
   /*


### PR DESCRIPTION
If AutoResume.NotIdle is set, the idling value must be to false in localStorage, otherwise, on
startup, if the value is at true, no interrupt will emit.

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/HackedByChinese/ng2-idle/blob/master/CONTRIBUTING.md#pr
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

Idling initial value wasn't set in localStorage, only in idle property.

**What is the new behavior?**

We initialize the idling value in localStorage at startup.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[X] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
