### PR TITLE
fix(idle):[On behalf of Lexmark International, Inc] Check expiry on t…

### DIFF
--- a/modules/core/src/idle.spec.ts
+++ b/modules/core/src/idle.spec.ts
@@ -404,6 +404,27 @@ describe('core/Idle', () => {
         instance.stop();
       }));
 
+      it('emits an onInterrupt event when the countdown ticks and expiry last has been updated', fakeAsync(() => {
+        spyOn(instance.onInterrupt, 'emit').and.callThrough();
+
+        instance.setTimeout(3);
+        expiry.mockNow = new Date();
+        instance.watch();
+
+        expiry.mockNow = new Date(expiry.now().getTime() + instance.getIdle() * 1000);
+        tick(3000);
+        expect(instance.isIdling()).toBe(true);
+
+        tick(1000);  // going once
+        tick(1000);  // going twice
+        expiry.last(new Date(expiry.now().getTime() + 6000));
+        tick(1000);  // going thrice
+
+        expect(instance.onInterrupt.emit).toHaveBeenCalledTimes(1);
+
+        instance.stop();
+      }));
+
       it('does not emit an onTimeoutWarning when timeout is disabled', fakeAsync(() => {
         spyOn(instance.onTimeoutWarning, 'emit').and.callThrough();
 

--- a/modules/core/src/idle.ts
+++ b/modules/core/src/idle.ts
@@ -343,6 +343,15 @@ export class Idle implements OnDestroy {
   }
 
   private doCountdown(): void {
+    let timeout = !this.timeoutVal ? 0 : this.timeoutVal;
+    let now: Date = this.expiry.now();
+    let diff: Number = this.expiry.last().getTime() - now.getTime() - (timeout * 1000);
+    if (diff > 0) {
+      this.safeClearInterval('timeoutHandle');
+      this.interrupt(true);
+      return;
+    }
+
     if (!this.idling) {
       return;
     }


### PR DESCRIPTION
…imeout doCountdown

Check expiry in doCountdown to see if it has changed and if so interrupt. For multi-tab support.

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/HackedByChinese/ng2-idle/blob/master/CONTRIBUTING.md#pr
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Currently when the timeout countdown starts when using multiple tabs dismissing the timeout on one tab does not dismiss the timeout on another tab. When the non-focused tab expires it then logs out both tabs.


**What is the new behavior?**
Dismissing one timeout countdown dismisses all tabs. Allowing user to remain active in all tabs.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[X] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
