### PR TITLE
Refactor/import of rxjs

### DIFF
--- a/modules/core/src/alternativestorage.ts
+++ b/modules/core/src/alternativestorage.ts
@@ -1,5 +1,6 @@
 /*
- * Represents an alternative storage for browser that doesn't support localstorage. (i.e. Safari in private mode)
+ * Represents an alternative storage for browser that doesn't support localstorage. (i.e. Safari in
+ * private mode)
  * @implements Storage
  */
 export class AlternativeStorage implements Storage {
@@ -10,7 +11,7 @@ export class AlternativeStorage implements Storage {
    */
   get length() {
     return Object.keys(this.storageMap).length;
-  };
+  }
 
   /*
    * Remove all keys out of the storage.
@@ -25,9 +26,9 @@ export class AlternativeStorage implements Storage {
    * @param key - name of the key to retrieve the value of.
    * @return The key's value
    */
-  getItem(key: string): string | null {
-    if (typeof this.storageMap[key] !== 'undefined' ) {
-        return this.storageMap[key];
+  getItem(key: string): string|null {
+    if (typeof this.storageMap[key] !== 'undefined') {
+      return this.storageMap[key];
     }
     return null;
   }
@@ -38,7 +39,7 @@ export class AlternativeStorage implements Storage {
    * @param index - the number of the key you want to get the name of.
    * @return The name of the key.
    */
-  key(index: number): string | null {
+  key(index: number): string|null {
     return Object.keys(this.storageMap)[index] || null;
   }
 
@@ -48,8 +49,8 @@ export class AlternativeStorage implements Storage {
    * @param key - the name of the key you want to remove.
    */
   removeItem(key: string): void {
-      this.storageMap[key] = undefined;
-  };
+    this.storageMap[key] = undefined;
+  }
 
   /*
    * Add a key to the storage, or update a key's value if it already exists.
@@ -58,10 +59,9 @@ export class AlternativeStorage implements Storage {
    * @param value - the value you want to give to the key.
    */
   setItem(key: string, value: string): void {
-      this.storageMap[key] = value;
-  };
+    this.storageMap[key] = value;
+  }
 
   [key: string]: any;
   [index: number]: string;
-
 }

--- a/modules/core/src/eventtargetinterruptsource.ts
+++ b/modules/core/src/eventtargetinterruptsource.ts
@@ -1,4 +1,8 @@
-import {Observable, Subscription} from 'rxjs/Rx';
+import 'rxjs/add/operator/throttleTime';
+import 'rxjs/add/observable/fromEvent';
+
+import {Observable} from 'rxjs/Observable';
+import {Subscription} from 'rxjs/Subscription';
 
 import {InterruptArgs} from './interruptargs';
 import {InterruptSource} from './interruptsource';

--- a/modules/core/src/idle.ts
+++ b/modules/core/src/idle.ts
@@ -31,16 +31,16 @@ export enum AutoResume {
  */
 @Injectable()
 export class Idle implements OnDestroy {
-  private idle: number = 20 * 60;   // in seconds
-  private timeoutVal: number = 30;  // in seconds
+  private idle: number = 20 * 60;  // in seconds
+  private timeoutVal = 30;         // in seconds
   private autoResume: AutoResume = AutoResume.idle;
   private interrupts: Array<Interrupt> = new Array;
-  private running: boolean = false;
+  private running = false;
   private idling: boolean;
   private idleHandle: any;
   private timeoutHandle: any;
   private countdown: number;
-  private keepaliveEnabled: boolean = false;
+  private keepaliveEnabled = false;
   private keepaliveSvc: KeepaliveSvc;
 
   public onIdleStart: EventEmitter<any> = new EventEmitter;
@@ -68,7 +68,8 @@ export class Idle implements OnDestroy {
     if (this.expiry instanceof LocalStorageExpiry) {
       this.expiry.setIdleName(key);
     } else {
-      throw new Error('Cannot set expiry key name because no LocalStorageExpiry has been provided.');
+      throw new Error(
+          'Cannot set expiry key name because no LocalStorageExpiry has been provided.');
     }
   }
 

--- a/modules/core/src/interrupt.ts
+++ b/modules/core/src/interrupt.ts
@@ -1,4 +1,4 @@
-import {Subscription} from 'rxjs/Rx';
+import {Subscription} from 'rxjs/Subscription';
 
 import {InterruptArgs} from './interruptargs';
 import {InterruptSource} from './interruptsource';

--- a/modules/core/src/interruptsource.ts
+++ b/modules/core/src/interruptsource.ts
@@ -6,7 +6,7 @@ import {InterruptArgs} from './interruptargs';
  * A base for classes that act as a source for interrupts.
  */
 export abstract class InterruptSource {
-  isAttached: boolean = false;
+  isAttached = false;
 
   public onInterrupt: EventEmitter<InterruptArgs> = new EventEmitter<InterruptArgs>();
 

--- a/modules/core/src/localstorage.ts
+++ b/modules/core/src/localstorage.ts
@@ -1,12 +1,11 @@
-import { Injectable } from '@angular/core';
-import { AlternativeStorage } from './alternativestorage';
+import {Injectable} from '@angular/core';
+import {AlternativeStorage} from './alternativestorage';
 
 /*
  * Represents a localStorage store.
  */
 @Injectable()
 export class LocalStorage {
-
   private storage: Storage;
 
   constructor() {
@@ -15,7 +14,8 @@ export class LocalStorage {
 
   /*
    * Safari, in Private Browsing Mode, looks like it supports localStorage but all calls to setItem
-   * throw QuotaExceededError. We're going to detect this and just silently drop any calls to setItem
+   * throw QuotaExceededError. We're going to detect this and just silently drop any calls to
+   * setItem
    * to avoid the entire page breaking, without having to do a check at each usage of Storage.
    */
   private getStorage(): Storage {
@@ -35,7 +35,7 @@ export class LocalStorage {
    * @param value - The value to get.
    * @return The current value.
    */
-  getItem(key: string): string | null {
+  getItem(key: string): string|null {
     return this.storage.getItem('ng2Idle.' + key);
   }
 
@@ -46,7 +46,7 @@ export class LocalStorage {
    */
   removeItem(key: string): void {
     this.storage.removeItem('ng2Idle.' + key);
-  };
+  }
 
   /*
    * Sets an item in the storage.
@@ -56,7 +56,7 @@ export class LocalStorage {
    */
   setItem(key: string, data: string): void {
     this.storage.setItem('ng2Idle.' + key, data);
-  };
+  }
 
   /*
    * Represents the storage, commonly use for testing purposes.
@@ -67,5 +67,4 @@ export class LocalStorage {
   _wrapped(): Storage {
     return this.storage;
   }
-
 }

--- a/modules/core/src/localstorageexpiry.ts
+++ b/modules/core/src/localstorageexpiry.ts
@@ -1,6 +1,6 @@
-import { Injectable } from '@angular/core';
-import { IdleExpiry } from './idleexpiry';
-import { LocalStorage } from './localstorage';
+import {Injectable} from '@angular/core';
+import {IdleExpiry} from './idleexpiry';
+import {LocalStorage} from './localstorage';
 
 /*
  * Represents a localStorage store of expiry values.
@@ -8,8 +8,7 @@ import { LocalStorage } from './localstorage';
  */
 @Injectable()
 export class LocalStorageExpiry extends IdleExpiry {
-
-  private idleName: string = 'main';
+  private idleName = 'main';
 
   constructor(private localStorage: LocalStorage) {
     super();
@@ -86,5 +85,4 @@ export class LocalStorageExpiry extends IdleExpiry {
       this.localStorage.setItem(this.idleName + '.idling', 'false');
     }
   }
-
 }

--- a/modules/core/testing/mockkeepalivesvc.ts
+++ b/modules/core/testing/mockkeepalivesvc.ts
@@ -1,7 +1,7 @@
 import {KeepaliveSvc} from '@ng-idle/core';
 
 export class MockKeepaliveSvc extends KeepaliveSvc {
-  isRunning: boolean = false;
+  isRunning = false;
 
   start(): void {
     this.isRunning = true;

--- a/package.json
+++ b/package.json
@@ -65,8 +65,8 @@
     "rxjs": "^5.2.0",
     "source-map-loader": "^0.1.5",
     "ts-helpers": "^1.1.2",
-    "tslint": "^3.15.0",
-    "tslint-loader": "^2.1.5",
+    "tslint": "^5.1.0",
+    "tslint-loader": "^3.5.2",
     "typescript": "2.1.5",
     "webpack": "2.1.0-beta.25",
     "zone.js": "^0.7.8 || ^0.8.4"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,8 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "allowSyntheticDefaultImports": true,
+    "allowUnreachableCode": false,
+    "allowUnusedLabels": false,
     "sourceMap": true,
     "noEmitHelpers": false,
     "strictNullChecks": false,

--- a/tslint.json
+++ b/tslint.json
@@ -15,7 +15,6 @@
     ],
     "jsdoc-format": true,
     "label-position": true,
-    "label-undefined": true,
     "max-line-length": [
       true,
       140
@@ -32,18 +31,16 @@
     ],
     "no-construct": true,
     "no-debugger": true,
-    "no-duplicate-key": true,
     "no-duplicate-variable": true,
     "no-empty": true,
     "no-eval": true,
-    "no-inferrable-types": true,
+    "no-inferrable-types": [true],
     "no-shadowed-variable": true,
     "no-string-literal": true,
     "no-switch-case-fall-through": true,
     "no-trailing-whitespace": true,
     "no-unused-expression": true,
-    "no-unused-variable": true,
-    "no-unreachable": true,
+    "no-unused-variable": [true],
     "no-use-before-declare": true,
     "no-var-keyword": true,
     "object-literal-sort-keys": true,
@@ -83,6 +80,8 @@
       "check-operator",
       "check-separator",
       "check-type"
-    ]
+    ],
+
+    "import-blacklist": [true, "rxjs", "rxjs/Rx"]
   }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/HackedByChinese/ng2-idle/blob/master/CONTRIBUTING.md#pr
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
rxjs has been imported using 'import from rxjs/Rx'
As explained in latest ng-conf talk (https://www.youtube.com/watch?v=aZRJOVPMW4k) this should be avoided as this not only imports the specified object (e.g. Observable) but everything (all operators, schedulers, ...).
Even when using tools like rollup und bundeling with webpack this gets the whole rxjs library into the bundle (even those things which are never needed).

Additional Resources:

- Reactive Programming with RxJS A Beginner’s Perspective - TRACY LEE and BEN LESH: https://www.youtube.com/watch?v=aZRJOVPMW4k
- Best Practice - STEPHEN FLUIN: https://www.youtube.com/watch?v=hHNUohOPCCo


**What is the new behavior?**
Imports have been changed to import only things which are required.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```


**Other information**:

In the first commit I just changed the imports

The second commit uses a rule from tslint (import-blacklist) - this rule was only added in a newer version of tslint - so I updated tslint dependency. Due to this I also needed to remove some old rules (seems like they are covered by the compiler). Moreover I encountered several tslint errors in different files when running tslint afterwards. 