### PR TITLE
chore(deps): support Angular 5, remove @angular/http references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Introduction
 [![Join the chat at https://gitter.im/HackedByChinese/ng2-idle](https://badges.gitter.im/HackedByChinese/ng2-idle.svg)](https://gitter.im/HackedByChinese/ng2-idle?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) [![Build Status](https://travis-ci.org/HackedByChinese/ng2-idle.svg?branch=master)](https://travis-ci.org/HackedByChinese/ng2-idle) [![Coverage Status](https://coveralls.io/repos/github/HackedByChinese/ng2-idle/badge.svg?branch=master)](https://coveralls.io/github/HackedByChinese/ng2-idle?branch=master)
 
-A module for responding to idle users in Angular 2+ applications. This is a rewrite of the [ng-idle module](https://github.com/HackedByChinese/ng-idle); however if you are using Angular 1, you must use that module.
+A module for responding to idle users in Angular 4+ applications. This is a rewrite of the [ng-idle module](https://github.com/HackedByChinese/ng-idle); however if you are using Angular 1, you must use that module.
 
 ## License
 Authored by **Mike Grabski** @HackedByChinese me@mikegrabski.com
@@ -51,7 +51,7 @@ Another feature ported from `ng-idle` is the ability to store an expiry value in
 By default, a `LocalStorageExpiry` type is provided, which will just keep track of the expiry in the localStorage. It will fulfill all purposes mentioned above. If you don't want to support multiple tabs or windows, you can use `SimpleExpiry`. In other words, `SimpleExpiry` does not coordinate last activity between tabs or windows. If you want to store the expiry value in another store, like cookies, you'll need to use or create an implementation that supports that. You can create your own by extending `IdleExpiry` or `SimpleExpiry` and configuring it as a provider for the `IdleExpiry` class.
 
 ### Multiple Idle Instance Support
-The dependency injector in Angular 2+ supports a hierarchical injection strategy. This allows you to create an instance of `Idle` at whatever scope you need, and there can be more than one instance. This allows you two have two separate watches, for example, on two different elements on the page.  
+The dependency injector in Angular 4+ supports a hierarchical injection strategy. This allows you to create an instance of `Idle` at whatever scope you need, and there can be more than one instance. This allows you two have two separate watches, for example, on two different elements on the page.  
 If you use the default expiry (`LocalStorageExpiry`), you will need to define a name for each idle with `Idle.setIdleName('yourIdleName')`, otherwise the same key will be used in the localStorage and this feature will not work as expected.
 
 ### Example Use Case

--- a/modules/keepalive/rollup.config.js
+++ b/modules/keepalive/rollup.config.js
@@ -9,7 +9,7 @@ export default {
   moduleName: 'ngidle.keepalive',
   globals: {
     '@angular/core': 'ng.core',
-    '@angular/http': 'ng.http',
+    '@angular/common/http': 'ng.http',
     'rxjs/Rx': 'Rx',
     '@ng-idle/core': 'ng.core'
   },

--- a/modules/keepalive/src/keepalive.ts
+++ b/modules/keepalive/src/keepalive.ts
@@ -1,5 +1,5 @@
 import {EventEmitter, Injectable, OnDestroy} from '@angular/core';
-import {Http, Request, RequestMethod, Response} from '@angular/http';
+import {HttpClient, HttpRequest, HttpResponse} from '@angular/common/http';
 import {KeepaliveSvc} from '@ng-idle/core';
 
 
@@ -8,7 +8,7 @@ import {KeepaliveSvc} from '@ng-idle/core';
  */
 @Injectable()
 export class Keepalive extends KeepaliveSvc implements OnDestroy {
-  private pingRequest: Request;
+  private pingRequest: HttpRequest<any>;
   private pingInterval: number = 10 * 60;
   private pingHandle: any;
 
@@ -20,13 +20,13 @@ export class Keepalive extends KeepaliveSvc implements OnDestroy {
   /*
    * An event emitted when the service has pinged an HTTP endpoint and received a response.
    */
-  public onPingResponse: EventEmitter<Response> = new EventEmitter<Response>();
+  public onPingResponse: EventEmitter<HttpResponse<any>> = new EventEmitter<HttpResponse<any>>();
 
   /*
    * Initializes a new instance of Keepalive
    * @param http - The HTTP service.
    */
-  constructor(private http: Http) {
+  constructor(private http: HttpClient) {
     super();
   }
 
@@ -35,10 +35,10 @@ export class Keepalive extends KeepaliveSvc implements OnDestroy {
    * @param url - The URL or Request object to use when pinging.
    * @return The current Request used when pinging.
    */
-  request(url?: string|Request): Request {
+  request<T>(url?: string | HttpRequest<T>): HttpRequest<T> {
     if (typeof url === 'string') {
-      this.pingRequest = new Request({method: RequestMethod.Get, url: url});
-    } else if (url instanceof Request) {
+      this.pingRequest = new HttpRequest<T>('GET', url);
+    } else if (url instanceof HttpRequest) {
       this.pingRequest = url;
     } else if (url === null) {
       this.pingRequest = null;
@@ -70,7 +70,7 @@ export class Keepalive extends KeepaliveSvc implements OnDestroy {
   ping(): void {
     this.onPing.emit(null);
     if (this.pingRequest) {
-      this.http.request(this.pingRequest).subscribe((response: Response) => {
+      this.http.request(this.pingRequest).subscribe((response: HttpResponse<any>) => {
         this.onPingResponse.emit(response);
       });
     }

--- a/modules/tsconfig.es5.json
+++ b/modules/tsconfig.es5.json
@@ -7,6 +7,7 @@
     "emitDecoratorMetadata": true,
     "outDir": "../.tmp/es5",
     "baseUrl": "./",
+    "rootDir": "./",
     "sourceMap": true,
     "removeComments": false,
     "moduleResolution": "node",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ng-idle-src",
   "version": "2.0.0-beta.12",
   "private": true,
-  "description": "A module for responding to idle users in Angular 2+ applications.",
+  "description": "A module for responding to idle users in Angular 4+ applications.",
   "scripts": {
     "clean": "npm cache clean && rimraf node_modules && rimraf coverage && rimraf dist && rimraf .tmp",
     "clean:dist": "rimraf dist && rimraf .tmp",
@@ -35,17 +35,17 @@
   },
   "homepage": "https://github.com/HackedByChinese/ng2-idle.git#readme",
   "devDependencies": {
-    "@angular/compiler": "^2.0.0 || ^4.0.0",
-    "@angular/compiler-cli": "^2.0.0 || ^4.0.0",
-    "@angular/platform-browser": "^2.0.0 || ^4.0.0",
-    "@angular/platform-browser-dynamic": "^2.0.0 || ^4.0.0",
+    "@angular/compiler": "^4.0.0 || ^5.0.0",
+    "@angular/compiler-cli": "^4.0.0 || ^5.0.0",
+    "@angular/platform-browser": "^4.0.0 || ^5.0.0",
+    "@angular/platform-browser-dynamic": "^4.0.0 || ^5.0.0",
     "@types/jasmine": "^2.5.37",
     "@types/node": "^6.0.46",
     "@types/source-map": "^0.1.29",
     "@types/webpack": "^1.12.35",
     "awesome-typescript-loader": "^3.0.3",
     "conventional-changelog-cli": "^1.2.0",
-    "core-js": "^2.4.1",
+    "core-js": "^2.5.1",
     "coveralls": "^2.11.15",
     "cz-conventional-changelog": "^1.1.6",
     "istanbul-instrumenter-loader": "0.2.0",
@@ -62,19 +62,18 @@
     "rimraf": "^2.5.4",
     "rollup": "^0.36.3",
     "rollup-plugin-uglify": "^1.0.1",
-    "rxjs": "^5.2.0",
+    "rxjs": "^5.5.2",
     "source-map-loader": "^0.1.5",
     "ts-helpers": "^1.1.2",
     "tslint": "^5.1.0",
     "tslint-loader": "^3.5.2",
-    "typescript": "2.1.5",
+    "typescript": "~2.4.2",
     "webpack": "2.1.0-beta.25",
-    "zone.js": "^0.7.8 || ^0.8.4"
+    "zone.js": "0.8.18"
   },
   "dependencies": {
-    "@angular/common": "^2.0.0 || ^4.0.0",
-    "@angular/core": "^2.0.0 || ^4.0.0",
-    "@angular/http": "^2.0.0 || ^4.0.0"
+    "@angular/common": "^4.0.0 || ^5.0.0",
+    "@angular/core": "^4.0.0 || ^5.0.0"
   },
   "config": {
     "commitizen": {

--- a/scripts/write-package-json.js
+++ b/scripts/write-package-json.js
@@ -14,9 +14,7 @@ modules.map(function(module) {
   pkg.version = basePkg.version;
   pkg.peerDependencies = Object.assign({}, basePkg.dependencies);
 
-  if (module !== 'keepalive') {
-    delete pkg.peerDependencies["@angular/http"];
-  } else {
+  if (module === 'keepalive') {
     pkg.peerDependencies['@ng-idle/core'] = '^' + basePkg.version;
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,43 +2,44 @@
 # yarn lockfile v1
 
 
-"@angular/common@^2.0.0 || ^4.0.0":
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/@angular/common/-/common-4.0.1.tgz#df488eada842b2d841ded750712292b18387b5b0"
-
-"@angular/compiler-cli@^2.0.0 || ^4.0.0":
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/@angular/compiler-cli/-/compiler-cli-4.0.1.tgz#90c60d491c12e1da901a0aeb3990470aa96e9bfa"
+"@angular/common@^4.0.0 || ^5.0.0":
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/@angular/common/-/common-5.0.5.tgz#a0530320beefa7b3446c7b5c6b10d7eda42b5998"
   dependencies:
-    "@angular/tsc-wrapped" "4.0.1"
+    tslib "^1.7.1"
+
+"@angular/compiler-cli@^4.0.0 || ^5.0.0":
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/@angular/compiler-cli/-/compiler-cli-5.0.5.tgz#4c25ce6f0a04eac9e56007be3639f86172a9c7ea"
+  dependencies:
+    chokidar "^1.4.2"
     minimist "^1.2.0"
     reflect-metadata "^0.1.2"
+    tsickle "^0.24.0"
 
-"@angular/compiler@^2.0.0 || ^4.0.0":
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/@angular/compiler/-/compiler-4.0.1.tgz#15721edb148167a2d83b6f9324817e658eac8280"
-
-"@angular/core@^2.0.0 || ^4.0.0":
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/@angular/core/-/core-4.0.1.tgz#0b110a001012076ea696460ccd922707bcdf51ba"
-
-"@angular/http@^2.0.0 || ^4.0.0":
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/@angular/http/-/http-4.0.1.tgz#bf87e7da9dc1f1567f246f9a09723e1cc3543d32"
-
-"@angular/platform-browser-dynamic@^2.0.0 || ^4.0.0":
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/@angular/platform-browser-dynamic/-/platform-browser-dynamic-4.0.1.tgz#fd5debb2d3f6474350965e71c2674e2170d7cfcb"
-
-"@angular/platform-browser@^2.0.0 || ^4.0.0":
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/@angular/platform-browser/-/platform-browser-4.0.1.tgz#4b9efbeb2fbb900de188743b988802d3aa2b33ff"
-
-"@angular/tsc-wrapped@4.0.1":
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/@angular/tsc-wrapped/-/tsc-wrapped-4.0.1.tgz#5323cc99263b097bceeb8e423270b5f58ffb2186"
+"@angular/compiler@^4.0.0 || ^5.0.0":
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/@angular/compiler/-/compiler-5.0.5.tgz#128329bd3a296116001480c56ecb95f0203aab07"
   dependencies:
-    tsickle "^0.21.0"
+    tslib "^1.7.1"
+
+"@angular/core@^4.0.0 || ^5.0.0":
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/@angular/core/-/core-5.0.5.tgz#9f032aff4cfacce0e33629338466f93bba4cbec4"
+  dependencies:
+    tslib "^1.7.1"
+
+"@angular/platform-browser-dynamic@^4.0.0 || ^5.0.0":
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/@angular/platform-browser-dynamic/-/platform-browser-dynamic-5.0.5.tgz#d7ac74c5ffd4c9a133ba90af160402266e92351d"
+  dependencies:
+    tslib "^1.7.1"
+
+"@angular/platform-browser@^4.0.0 || ^5.0.0":
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/@angular/platform-browser/-/platform-browser-5.0.5.tgz#71039c85b2bc5e3f4405151ffd1e2096c4f373a1"
+  dependencies:
+    tslib "^1.7.1"
 
 "@types/jasmine@^2.5.37":
   version "2.5.47"
@@ -502,7 +503,7 @@ chalk@1.1.3, chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chokidar@^1.4.1, chokidar@^1.4.3:
+chokidar@^1.4.1, chokidar@^1.4.2, chokidar@^1.4.3:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-1.6.1.tgz#2f4447ab5e96e50fb3d789fd90d4c72e0e4c70c2"
   dependencies:
@@ -773,9 +774,13 @@ cookie@0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz#e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb"
 
-core-js@^2.2.0, core-js@^2.4.1:
+core-js@^2.2.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.4.1.tgz#4de911e667b0eae9124e34254b53aea6fc618d3e"
+
+core-js@^2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.1.tgz#ae6874dc66937789b80754ff5428df66819ca50b"
 
 core-util-is@~1.0.0:
   version "1.0.2"
@@ -2830,9 +2835,9 @@ rollup@^0.36.3:
   dependencies:
     source-map-support "^0.4.0"
 
-rxjs@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.2.0.tgz#db537de8767c05fa73721587a29e0085307d318b"
+rxjs@^5.5.2:
+  version "5.5.3"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.3.tgz#b62227e74b84f4e77bdf440e50b5ee01a1bc7dcd"
   dependencies:
     symbol-observable "^1.0.1"
 
@@ -2840,13 +2845,13 @@ safe-buffer@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.0.1.tgz#d263ca54696cd8a306b5ca6551e92de57918fbe7"
 
-"semver@2 || 3 || 4 || 5", semver@~4.3.3:
-  version "4.3.6"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-4.3.6.tgz#300bc6e0e86374f7ba61068b5b1ecd57fc6532da"
-
-semver@^5.0.1, semver@^5.3.0:
+"semver@2 || 3 || 4 || 5", semver@^5.0.1, semver@^5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
+
+semver@~4.3.3:
+  version "4.3.6"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-4.3.6.tgz#300bc6e0e86374f7ba61068b5b1ecd57fc6532da"
 
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
@@ -3178,14 +3183,18 @@ ts-helpers@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/ts-helpers/-/ts-helpers-1.1.2.tgz#fc69be9f1f3baed01fb1a0ef8d4cfe748814d835"
 
-tsickle@^0.21.0:
-  version "0.21.6"
-  resolved "https://registry.yarnpkg.com/tsickle/-/tsickle-0.21.6.tgz#53b01b979c5c13fdb13afb3fb958177e5991588d"
+tsickle@^0.24.0:
+  version "0.24.1"
+  resolved "https://registry.yarnpkg.com/tsickle/-/tsickle-0.24.1.tgz#039343b205bf517a333b0703978892f80a7d848e"
   dependencies:
     minimist "^1.2.0"
     mkdirp "^0.5.1"
     source-map "^0.5.6"
     source-map-support "^0.4.2"
+
+tslib@^1.7.1:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.8.0.tgz#dc604ebad64bcbf696d613da6c954aa0e7ea1eb6"
 
 tslint-loader@^3.5.2:
   version "3.5.2"
@@ -3246,9 +3255,9 @@ type-is@~1.6.14:
     media-typer "0.3.0"
     mime-types "~2.1.13"
 
-typescript@2.1.5:
-  version "2.1.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.1.5.tgz#6fe9479e00e01855247cea216e7561bafcdbcd4a"
+typescript@~2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.4.2.tgz#f8395f85d459276067c988aa41837a8f82870844"
 
 uglify-js@^2.6, uglify-js@^2.6.1:
   version "2.8.18"
@@ -3512,6 +3521,6 @@ yeast@0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/yeast/-/yeast-0.1.2.tgz#008e06d8094320c372dbc2f8ed76a0ca6c8ac419"
 
-"zone.js@^0.7.8 || ^0.8.4":
-  version "0.8.5"
-  resolved "https://registry.yarnpkg.com/zone.js/-/zone.js-0.8.5.tgz#7906e017482cbff4c3f079c5c34305ce941f5ba2"
+zone.js@0.8.18:
+  version "0.8.18"
+  resolved "https://registry.yarnpkg.com/zone.js/-/zone.js-0.8.18.tgz#8cecb3977fcd1b3090562ff4570e2847e752b48d"


### PR DESCRIPTION
Support Angular 4 & 5 dependencies, remove references to deprecated `@angular/http` module in favor of `@angular/common/http`

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/HackedByChinese/ng2-idle/blob/master/CONTRIBUTING.md#pr
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

See #68 and #69.

**What is the new behavior?**



**Does this PR introduce a breaking change?** (check one with "x")
```
[x] Yes
[ ] No
```

- Support for Angular 2.x dropped due to missing `@angular/common/http` dependency

**Other information**:

Also, are tests in master currently broken, or is my environment acting up? Getting 30 failed test cases...