### PR TITLE
Feature/run outside angular

### DIFF
--- a/modules/core/src/eventtargetinterruptsource.spec.ts
+++ b/modules/core/src/eventtargetinterruptsource.spec.ts
@@ -32,6 +32,31 @@ describe('core/EventTargetInterruptSource', () => {
       source.detach();
     }));
 
+
+  it('emits onInterrupt event outside the angular zone', fakeAsync(() => {
+    let fakeNgZone = Zone.current.fork({
+      name: 'angular',
+      properties: {
+        isAngularZone: true
+      }
+    });
+
+    fakeNgZone.run(() => {
+      let source = new EventTargetInterruptSource(document.body, 'click');
+
+      source.onInterrupt.subscribe(arg => {
+        expect(Zone.current.get('isAngularZone')).toBeFalsy();
+      });
+
+      source.attach();
+      let expected = new Event('click');
+      document.body.dispatchEvent(expected);
+      source.detach();
+    });
+  }));
+
+
+
   it('does not emit onInterrupt event when detached and event is fired', fakeAsync(() => {
     let source = new EventTargetInterruptSource(document.body, 'click');
     spyOn(source.onInterrupt, 'emit').and.callThrough();

--- a/modules/core/src/eventtargetinterruptsource.ts
+++ b/modules/core/src/eventtargetinterruptsource.ts
@@ -64,6 +64,13 @@ export class EventTargetInterruptSource extends InterruptSource {
 
     this.attachFn = () => this.eventSubscription = this.eventSrc.subscribe(handler);
 
+    // If the current zone is the 'angular' zone (a.k.a. NgZone) then bind the attachFn to its parent
+    // The parent zone is usually the '<root>' zone but it can also be 'long-stack-trace-zone' in debug mode
+    // In tests, the current zone is typically a 'ProxyZone' created by async/fakeAsync (from @angular/core/testing)
+    if (Zone.current.get('isAngularZone') === true) {
+      this.attachFn = Zone.current.parent.wrap(this.attachFn, Zone.current.name);
+    }
+
     this.detachFn = () => this.eventSubscription.unsubscribe();
   }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,7 +23,8 @@
       "jasmine",
       "node",
       "source-map",
-      "webpack"
+      "webpack",
+      "zone.js"
     ]
   },
   "exclude": [


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/HackedByChinese/ng2-idle/blob/master/CONTRIBUTING.md#pr
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Angular spies on every event handler that is attached to the document root element and processes change detection whenever an event is dispatched by the browser. That's pretty bad for performance.


**What is the new behavior?**
This PR changes `EventTargetInterruptOptions` to attach event handlers outside the Angular zone so that no change detection is processed for each event.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
