### PR TITLE
Run outside angular

### DIFF
--- a/modules/core/src/interruptsource.ts
+++ b/modules/core/src/interruptsource.ts
@@ -1,6 +1,6 @@
-import {EventEmitter} from '@angular/core';
+import { EventEmitter } from '@angular/core';
 
-import {InterruptArgs} from './interruptargs';
+import { InterruptArgs } from './interruptargs';
 
 /*
  * A base for classes that act as a source for interrupts.
@@ -11,13 +11,21 @@ export abstract class InterruptSource {
   public onInterrupt: EventEmitter<InterruptArgs> = new EventEmitter<InterruptArgs>();
 
   constructor(
-      protected attachFn?: (source: InterruptSource) => void,
-      protected detachFn?: (source: InterruptSource) => void) {}
+    protected attachFn?: (source: InterruptSource) => void,
+    protected detachFn?: (source: InterruptSource) => void) { }
 
   /*
    * Attaches to the specified events on the specified source.
    */
   attach(): void {
+    // If the current zone is the 'angular' zone (a.k.a. NgZone) then re-enter this method in its parent zone
+    // The parent zone is usually the '<root>' zone but it can also be 'long-stack-trace-zone' in debug mode
+    // In tests, the current zone is typically a 'ProxyZone' created by async/fakeAsync (from @angular/core/testing)
+    if (Zone.current.get('isAngularZone') === true) {
+      Zone.current.parent.run(() => this.attach());
+      return;
+    }
+
     if (!this.isAttached && this.attachFn) {
       this.attachFn(this);
     }

--- a/modules/tsconfig.es5.json
+++ b/modules/tsconfig.es5.json
@@ -17,7 +17,8 @@
       "dom"
     ],
     "types": [
-      "jasmine"
+      "jasmine",
+      "zone.js"
     ],
     "paths": {
       "@ng-idle/core": ["./core"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,7 +23,8 @@
       "jasmine",
       "node",
       "source-map",
-      "webpack"
+      "webpack",
+      "zone.js"
     ]
   },
   "exclude": [


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/HackedByChinese/ng2-idle/blob/master/CONTRIBUTING.md#pr
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Angular spies on every event handler that is attached to the document root element and processes change detection whenever an event is dispatched by the browser. That's pretty bad for performance.


**What is the new behavior?**
This PR changes `InterruptSource` to attach event handlers outside the Angular zone so that no change detection is processed for each event.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
