### PR TITLE
fix(issue #77): do not use document and window in SSR

### DIFF
--- a/modules/core/src/documentinterruptsource.ts
+++ b/modules/core/src/documentinterruptsource.ts
@@ -1,11 +1,13 @@
-import { EventTargetInterruptOptions, EventTargetInterruptSource } from './eventtargetinterruptsource';
+import {EventTargetInterruptOptions, EventTargetInterruptSource} from './eventtargetinterruptsource';
 
 /*
  * An interrupt source that uses events on the document element (html tag).
  */
 export class DocumentInterruptSource extends EventTargetInterruptSource {
   constructor(events: string, options?: number | EventTargetInterruptOptions) {
-    super(document.documentElement, events, options);
+    if (typeof document !== 'undefined') {
+      super(document.documentElement, events, options);
+    }
   }
 
   /*

--- a/modules/core/src/windowinterruptsource.ts
+++ b/modules/core/src/windowinterruptsource.ts
@@ -5,6 +5,8 @@ import {EventTargetInterruptOptions, EventTargetInterruptSource} from './eventta
  */
 export class WindowInterruptSource extends EventTargetInterruptSource {
   constructor(events: string, options?: number | EventTargetInterruptOptions) {
-    super(window, events, options);
+    if (typeof window !== 'undefined') {
+      super(window, events, options);
+    }
   }
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix : 
```
Should be able to run angular project using server side rendering with ng-idle.

**What is the current behavior?** (You can also link to an open issue here)
Issue #77
ps: This PR (https://github.com/HackedByChinese/ng2-idle/pull/90) is working too. 
Window and document is not defined in angular universal server side.

**What is the new behavior?**
Works with SSR.


**Does this PR introduce a breaking change?** (check one with "x")
```
[x] No
```