### PR TITLE
Fixed console error on manual localStorage clear

### DIFF
--- a/modules/core/src/storageinterruptsource.ts
+++ b/modules/core/src/storageinterruptsource.ts
@@ -14,7 +14,7 @@ export class StorageInterruptSource extends WindowInterruptSource {
    * @return True if the event should be filtered (don't cause an interrupt); otherwise, false.
    */
   filterEvent(event: StorageEvent): boolean {
-    if (event.key.indexOf('ng2Idle.') >= 0 && event.key.indexOf('.expiry') >= 0) {
+    if (event.key && event.key.indexOf('ng2Idle.') >= 0 && event.key.indexOf('.expiry') >= 0) {
       return false;
     }
     return true;


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[ x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
When localStorage is cleared manually from Application > LocalStorage > clear button, this will throw console error TypeError: Cannot read property 'indexOf' of null.


**What is the new behavior?**
No console errors will be thrown from now.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ x ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...
None

**Other information**:
