### PR TITLE
Fix keepalive onPingResponse subscribe response doesnt work right #118

### DIFF
--- a/modules/keepalive/src/keepalive.spec.ts
+++ b/modules/keepalive/src/keepalive.spec.ts
@@ -106,14 +106,49 @@ describe('keepalive/Keepalive', () => {
     it('ping() should fire request and emit onPingResponse event', () => {
       let actualResponse: HttpResponse<{}>;
 
-      instance.onPingResponse.subscribe((response: HttpResponse<{}>) => {
-        actualResponse = response;
-      });
+      instance.onPingResponse.subscribe(
+        (response: HttpResponse<{}>) => {
+          actualResponse = response;
+        },
+        (error: HttpResponse<{}>) => {
+          actualResponse = error;
+        });
 
       instance.ping();
 
       httpMock.expectOne(request.url).flush(null, {status: 200, statusText: 'OK'});
       expect(actualResponse.status).toBe(200);
+    });
+  });
+
+  describe('using an HTTP request that results in error', () => {
+
+    let request = new HttpRequest('GET', 'https://test.com/404');
+
+    beforeEach(() => {
+      instance = TestBed.get(Keepalive);
+      instance.request(request);
+    });
+
+    afterEach(() => {
+      httpMock.verify();
+    });
+
+    it('ping() should fire request and emit onPingResponse event', () => {
+      let actualResponse: HttpResponse<{}>;
+
+      instance.onPingResponse.subscribe(
+        (response: HttpResponse<{}>) => {
+          actualResponse = response;
+        },
+        (error: HttpResponse<{}>) => {
+          actualResponse = error;
+        });
+
+      instance.ping();
+
+      httpMock.expectOne(request.url).flush(null, {status: 404, statusText: 'Error'});
+      expect(actualResponse.status).toBe(404);
     });
   });
 

--- a/modules/keepalive/src/keepalive.ts
+++ b/modules/keepalive/src/keepalive.ts
@@ -1,6 +1,6 @@
-import {EventEmitter, Injectable, OnDestroy} from '@angular/core';
-import {HttpClient, HttpRequest, HttpResponse} from '@angular/common/http';
-import {KeepaliveSvc} from '@ng-idle/core';
+import { EventEmitter, Injectable, OnDestroy } from '@angular/core';
+import { HttpClient, HttpRequest, HttpResponse } from '@angular/common/http';
+import { KeepaliveSvc } from '@ng-idle/core';
 
 
 /**
@@ -70,9 +70,14 @@ export class Keepalive extends KeepaliveSvc implements OnDestroy {
   ping(): void {
     this.onPing.emit(null);
     if (this.pingRequest) {
-      this.http.request(this.pingRequest).subscribe((response: HttpResponse<any>) => {
-        this.onPingResponse.emit(response);
-      });
+      this.http.request(this.pingRequest).subscribe(
+        (response: HttpResponse<any>) => {
+          this.onPingResponse.emit(response);
+        },
+        (error: HttpResponse<any>) => {
+          this.onPingResponse.emit(error);
+        }
+      );
     }
   }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/HackedByChinese/ng2-idle/blob/master/CONTRIBUTING.md#pr
- [x] Tests for the changes have been added (for bug fixes / features)
- [] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
[keepalive onPingResponse subscribe response doesnt work right #118](https://github.com/HackedByChinese/ng2-idle/issues/118)


**What is the new behavior?**



**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
