### PR TITLE
chore: upgrade peer dependencies to include Angular 7

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,8 +72,8 @@
     "zone.js": "~0.8.26"
   },
   "dependencies": {
-    "@angular/common": "^6.0.0",
-    "@angular/core": "^6.0.0"
+    "@angular/common": "^6.0.0||^7.0.0",
+    "@angular/core": "^6.0.0||^7.0.0"
   },
   "config": {
     "commitizen": {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/HackedByChinese/ng2-idle/blob/master/CONTRIBUTING.md#pr
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Other... Please describe:
```
Allow Angular 7 core and common modules to be peer dependencies.

**What is the current behavior?** (You can also link to an open issue here)

When doing an npm ls --depth=0, the following errors are indicated when ng-idle core is being used with an Angular 7 application:
npm ERR! peer dep missing: @angular/common@^6.0.0, required by @ng-idle/core@6.0.0-beta.3
npm ERR! peer dep missing: @angular/core@^6.0.0, required by @ng-idle/core@6.0.0-beta.3

**What is the new behavior?**

Angular 7 core and common modules can be peer dependencies.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
