### PR TITLE
Fixes bug #113: Run keepalive setInterval outside NgZone

### DIFF
--- a/modules/keepalive/src/keepalive.ts
+++ b/modules/keepalive/src/keepalive.ts
@@ -1,4 +1,4 @@
-import { EventEmitter, Injectable, OnDestroy } from '@angular/core';
+import { EventEmitter, Injectable, NgZone, OnDestroy } from '@angular/core';
 import { HttpClient, HttpRequest, HttpResponse } from '@angular/common/http';
 import { KeepaliveSvc } from '@ng-idle/core';
 
@@ -26,7 +26,7 @@ export class Keepalive extends KeepaliveSvc implements OnDestroy {
    * Initializes a new instance of Keepalive
    * @param http - The HTTP service.
    */
-  constructor(private http: HttpClient) {
+  constructor(private http: HttpClient, private zone: NgZone) {
     super();
   }
 
@@ -87,9 +87,13 @@ export class Keepalive extends KeepaliveSvc implements OnDestroy {
   start(): void {
     this.stop();
 
-    this.pingHandle = setInterval(() => {
-      this.ping();
-    }, this.pingInterval * 1000);
+    this.zone.runOutsideAngular(() => {
+      this.pingHandle = setInterval(() => {
+        this.zone.run(() => {
+          this.ping();
+        });
+      }, this.pingInterval * 1000);
+    });
   }
 
   /*


### PR DESCRIPTION
This is a fix for issue #113 to allow Protractor to continue without waiting for synchronization with Angular.

issue #113

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/HackedByChinese/ng2-idle/blob/master/CONTRIBUTING.md#pr
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
https://github.com/HackedByChinese/ng2-idle/issues/113


**What is the new behavior?**



**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
